### PR TITLE
feat: endpoints v2

### DIFF
--- a/src/api/endpoints/auth/get-login-v3.ts
+++ b/src/api/endpoints/auth/get-login-v3.ts
@@ -1,8 +1,8 @@
 import { Schema } from 'effect'
 
-import { apiPath, makeEndpoint } from '../helpers'
+import { makeEndpoint } from '../helpers'
 
-const responseSchema = Schema.Struct({
+const schema = Schema.Struct({
   flows: Schema.Array(Schema.Struct({ type: Schema.String })),
 })
 
@@ -14,10 +14,4 @@ const responseSchema = Schema.Struct({
  *
  * @see https://spec.matrix.org/v1.17/client-server-api/#get_matrixclientv3login
  */
-export const getLoginV3 = () =>
-  makeEndpoint({
-    path: apiPath()`/v3/login`,
-    method: 'GET',
-    auth: false,
-    schema: responseSchema,
-  })
+export const getLoginV3 = () => makeEndpoint('GET', { auth: false, schema })`/v3/login`

--- a/src/api/endpoints/auth/post-login-v3.ts
+++ b/src/api/endpoints/auth/post-login-v3.ts
@@ -3,7 +3,7 @@ import { HttpBody } from 'effect/unstable/http'
 
 import { encodeSnakeCaseSchema } from '../../schema/encode-case'
 import { DiscoveryInformationResponseSchema } from '../../schema/rest'
-import { apiPath, makeEndpoint } from '../helpers'
+import { makeEndpoint } from '../helpers'
 
 const commonOptionsSchema = Schema.Struct({
   initialDeviceDisplayName: Schema.optional(Schema.String),
@@ -27,7 +27,7 @@ const optionsSchema = Schema.Union([
   }),
 ])
 
-const responseSchema = Schema.Struct({
+const schema = Schema.Struct({
   accessToken: Schema.String,
   deviceId: Schema.String,
   userId: Schema.String,
@@ -47,11 +47,6 @@ export const postLoginV3 = (options: Schema.Schema.Type<typeof optionsSchema>) =
   Effect.gen(function* () {
     //TODO: this is weird encodeSnakeCaseSchema should not be exposed like this
     const body = yield* Schema.encodeEffect(optionsSchema.pipe(encodeSnakeCaseSchema))(options).pipe(Effect.andThen(HttpBody.json))
-    return yield* makeEndpoint({
-      auth: false,
-      method: 'POST',
-      path: apiPath()`/v3/login`,
-      body,
-      schema: responseSchema,
-    })
+
+    return yield* makeEndpoint('POST', { auth: false, body, schema })`/v3/login`
   })

--- a/src/api/endpoints/capabilities/get-capabilities-v3.ts
+++ b/src/api/endpoints/capabilities/get-capabilities-v3.ts
@@ -1,6 +1,6 @@
 import { Schema } from 'effect'
 
-import { apiPath, makeEndpoint } from '../helpers'
+import { makeEndpoint } from '../helpers'
 
 const booleanCapabilitySchema = Schema.Struct({
   enabled: Schema.Boolean,
@@ -17,7 +17,7 @@ const roomVersionsCapability = Schema.Struct({
   available: Schema.Record(Schema.String, Schema.String),
 })
 
-const responseSchema = Schema.Struct({
+const schema = Schema.Struct({
   capabilities: Schema.Struct({
     'm.3pid_changes': booleanCapabilitySchema,
     'm.change_password': booleanCapabilitySchema,
@@ -39,10 +39,4 @@ const responseSchema = Schema.Struct({
  *
  * @see https://spec.matrix.org/v1.17/client-server-api/#get_matrixclientv3capabilities
  */
-export const getCapabilitiesV3 = () =>
-  makeEndpoint({
-    path: apiPath()`/v3/capabilities`,
-    method: 'GET',
-    auth: true,
-    schema: responseSchema,
-  })
+export const getCapabilitiesV3 = () => makeEndpoint('GET', { auth: true, schema })`/v3/capabilities`

--- a/src/api/endpoints/discovery/get-well-known.ts
+++ b/src/api/endpoints/discovery/get-well-known.ts
@@ -1,9 +1,9 @@
 import { Schema } from 'effect'
 
 import type { ServerName } from '../../../branded/server-name'
-import { apiPath, makeEndpoint } from '../helpers'
+import { makeEndpoint } from '../helpers'
 
-const responseSchema = Schema.Struct({
+const schema = Schema.Struct({
   'm.homeserver': Schema.Struct({
     baseUrl: Schema.String,
   }),
@@ -18,9 +18,4 @@ const responseSchema = Schema.Struct({
  * @see https://spec.matrix.org/v1.17/client-server-api/#getwell-knownmatrixclient
  */
 export const getWellKnown = ({ serverName }: { serverName: ServerName }) =>
-  makeEndpoint({
-    path: apiPath({ encode: false })`https://${serverName}/.well-known/matrix/client`,
-    method: 'GET',
-    auth: false,
-    schema: responseSchema,
-  })
+  makeEndpoint('GET', { auth: false, schema, encode: false })`https://${serverName}/.well-known/matrix/client`

--- a/src/api/endpoints/helpers.ts
+++ b/src/api/endpoints/helpers.ts
@@ -16,7 +16,45 @@ export type MatrixEndpoint<S extends Schema.Top> = {
     }
 )
 
-export const makeEndpoint = <S extends Schema.Top>(endpoint: MatrixEndpoint<S>) => Effect.succeed(endpoint)
+const makeEndpointFromConfig = <S extends Schema.Top>(endpoint: MatrixEndpoint<S>) => Effect.succeed(endpoint)
+
+type PathValue = string | number
+
+type EndpointBaseOptions<S extends Schema.Top> = {
+  schema: S
+  params?: UrlParams.Input
+  encode?: boolean
+}
+
+type EndpointWithBodyOptions<S extends Schema.Top> = EndpointBaseOptions<S> & {
+  auth: boolean
+  body?: HttpBody.HttpBody
+}
+
+type GetOptions<S extends Schema.Top> = EndpointBaseOptions<S> & { auth: boolean }
+type WriteOptions<S extends Schema.Top> = EndpointWithBodyOptions<S>
+
+export function makeEndpoint<S extends Schema.Top>(
+  method: 'GET',
+  options: GetOptions<S>,
+): (strings: TemplateStringsArray, ...values: readonly PathValue[]) => Effect.Effect<MatrixEndpoint<S>>
+export function makeEndpoint<S extends Schema.Top>(
+  method: 'POST' | 'PUT' | 'DELETE' | 'PATCH',
+  options: WriteOptions<S>,
+): (strings: TemplateStringsArray, ...values: readonly PathValue[]) => Effect.Effect<MatrixEndpoint<S>>
+export function makeEndpoint<S extends Schema.Top>(method: MatrixEndpoint<S>['method'], options: GetOptions<S> | WriteOptions<S>) {
+  const encode = options.encode ?? true
+
+  return (strings: TemplateStringsArray, ...values: readonly PathValue[]) =>
+    makeEndpointFromConfig({
+      auth: options.auth,
+      method,
+      path: apiPath({ encode })(strings, ...values),
+      params: options.params,
+      schema: options.schema,
+      body: method === 'GET' ? undefined : 'body' in options ? options.body : undefined,
+    } as MatrixEndpoint<S>)
+}
 
 export const makeHttpRequest = <S extends Schema.Top>(endpoint: MatrixEndpoint<S>) =>
   Effect.succeed(

--- a/src/api/endpoints/profile/get-profile-v3.ts
+++ b/src/api/endpoints/profile/get-profile-v3.ts
@@ -2,9 +2,9 @@ import { Schema } from 'effect'
 
 import { MxcUri } from '../../../branded/mxc-uri'
 import { UserId } from '../../../branded/user-id'
-import { apiPath, makeEndpoint } from '../helpers'
+import { makeEndpoint } from '../helpers'
 
-const responseSchema = Schema.Struct({
+const schema = Schema.Struct({
   avatarUrl: Schema.optional(Schema.NullOr(MxcUri.schema)),
   displayname: Schema.optional(Schema.String),
   //TODO: Make versioned fields
@@ -21,13 +21,7 @@ const responseSchema = Schema.Struct({
  *
  * @see https://spec.matrix.org/v1.17/client-server-api/#get_matrixclientv3profileuserid
  */
-export const getProfileV3 = ({ userId }: { userId: UserId }) =>
-  makeEndpoint({
-    path: apiPath()`/v3/profile/${userId}`,
-    method: 'GET',
-    auth: true,
-    schema: responseSchema,
-  })
+export const getProfileV3 = ({ userId }: { userId: UserId }) => makeEndpoint('GET', { auth: true, schema })`/v3/profile/${userId}`
 
 /*
  * TODO: explore this pattern:

--- a/src/api/endpoints/rooms/get-rooms-event-v3.ts
+++ b/src/api/endpoints/rooms/get-rooms-event-v3.ts
@@ -1,0 +1,18 @@
+import type { EventId, RoomId } from '../../../branded'
+import { RoomEvent } from '../../schema/common'
+import { makeEndpoint } from '../helpers'
+
+const schema = RoomEvent
+
+/**
+ * `GET /_matrix/client/v3/rooms/{roomId}/events/{eventId}`
+ *
+ * @description
+ * Get a single event based on roomId/eventId. You must have permission to retrieve this event e.g. by being a member in the room for
+ * this event.
+ *
+ * @see https://spec.matrix.org/v1.17/client-server-api/#get_matrixclientv3roomsroomideventeventid
+ */
+export const getRoomsEvent = ({ roomId, eventId }: { roomId: RoomId; eventId: EventId }) => {
+  return makeEndpoint('GET', { auth: true, schema })`/v3/rooms/${roomId}/events/${eventId}`
+}

--- a/src/api/endpoints/rooms/index.ts
+++ b/src/api/endpoints/rooms/index.ts
@@ -1,2 +1,3 @@
 export * from './post-rooms-join-v3'
 export * from './put-rooms-send-v3'
+export * from './get-rooms-event-v3'

--- a/src/api/endpoints/rooms/post-rooms-join-v3.ts
+++ b/src/api/endpoints/rooms/post-rooms-join-v3.ts
@@ -1,9 +1,9 @@
 import { Schema } from 'effect'
 
 import { RoomId } from '../../../branded/room-id'
-import { apiPath, makeEndpoint } from '../helpers'
+import { makeEndpoint } from '../helpers'
 
-const responseSchema = Schema.Struct({
+const schema = Schema.Struct({
   roomId: RoomId.schema,
 })
 
@@ -19,10 +19,4 @@ const responseSchema = Schema.Struct({
  *
  * @see https://spec.matrix.org/v1.17/client-server-api/#post_matrixclientv3roomsroomidjoin
  */
-export const postRoomsJoinV3 = ({ roomId }: { roomId: RoomId }) =>
-  makeEndpoint({
-    path: apiPath()`/v3/rooms/${roomId}/join`,
-    method: 'POST',
-    auth: true,
-    schema: responseSchema,
-  })
+export const postRoomsJoinV3 = ({ roomId }: { roomId: RoomId }) => makeEndpoint('POST', { auth: true, schema })`/v3/rooms/${roomId}/join`

--- a/src/api/endpoints/rooms/put-rooms-send-v3.ts
+++ b/src/api/endpoints/rooms/put-rooms-send-v3.ts
@@ -3,9 +3,9 @@ import { HttpBody } from 'effect/unstable/http'
 
 import { EventId, RoomId } from '../../../branded'
 import { encodeSnakeCaseSchema } from '../../schema/encode-case'
-import { makeEndpoint, apiPath } from '../helpers'
+import { makeEndpoint } from '../helpers'
 
-const responseSchema = Schema.Struct({
+const schema = Schema.Struct({
   eventId: EventId.schema,
 })
 
@@ -60,11 +60,5 @@ export const putRoomsSendV3 = (options: typeof optionsSchema.Type) =>
 
     const transactionId = options.transactionId ? options.transactionId : yield* Random.nextUUIDv4
 
-    return yield* makeEndpoint({
-      path: apiPath()`/v3/rooms/${options.roomId}/send/${options.eventType}/${transactionId}`,
-      method: 'PUT',
-      auth: true,
-      schema: responseSchema,
-      body,
-    })
+    return yield* makeEndpoint('PUT', { auth: true, schema, body })`/v3/rooms/${options.roomId}/send/${options.eventType}/${transactionId}`
   })

--- a/src/api/endpoints/sync/get-sync-v3.ts
+++ b/src/api/endpoints/sync/get-sync-v3.ts
@@ -3,7 +3,7 @@ import { Effect, Schema } from 'effect'
 import { EventId } from '../../../branded/event-id'
 import { RoomId } from '../../../branded/room-id'
 import { AccountData, BaseEvent, StateSchema, StrippedStateEvent, Timeline } from '../../schema/common'
-import { apiPath, makeEndpoint } from '../helpers'
+import { makeEndpoint } from '../helpers'
 
 const presenceSchema = Schema.Union([Schema.Literal('online'), Schema.Literal('offline'), Schema.Literal('unavailable')])
 
@@ -16,6 +16,7 @@ const optionsSchema = Schema.Struct({
   useStateAfter: Schema.optional(Schema.Boolean),
 })
 
+//TODO: don't export this from here, it's noy only used in this endpoint
 export const getSyncV3ResponseSchema = Schema.Struct({
   accountData: Schema.optional(AccountData),
   deviceLists: Schema.optional(Schema.Any), //TODO
@@ -88,6 +89,8 @@ export const getSyncV3ResponseSchema = Schema.Struct({
   toDevice: Schema.optional(Schema.Struct({ events: Schema.Array(BaseEvent) })),
 })
 
+const schema = getSyncV3ResponseSchema
+
 /**
  * `GET /_matrix/client/v3/sync`
  *
@@ -102,11 +105,9 @@ export const getSyncV3 = (options: typeof optionsSchema.Type) =>
   Effect.gen(function* () {
     const params = yield* Schema.encodeEffect(optionsSchema)(options)
 
-    return yield* makeEndpoint({
-      path: apiPath()`/v3/sync`,
-      method: 'GET',
+    return yield* makeEndpoint('GET', {
       auth: true,
       params,
-      schema: getSyncV3ResponseSchema,
-    })
+      schema,
+    })`/v3/sync`
   })

--- a/src/api/endpoints/user-directory/post-user-directory-search-v3.ts
+++ b/src/api/endpoints/user-directory/post-user-directory-search-v3.ts
@@ -3,7 +3,7 @@ import { HttpBody } from 'effect/unstable/http'
 
 import { MxcUri } from '../../../branded/mxc-uri'
 import { encodeSnakeCaseSchema } from '../../schema/encode-case'
-import { apiPath, makeEndpoint } from '../helpers'
+import { makeEndpoint } from '../helpers'
 
 const optionsSchema = Schema.Struct({
   limit: Schema.optional(Schema.Int),
@@ -16,7 +16,7 @@ const userResponseSchema = Schema.Struct({
   userId: Schema.String,
 })
 
-const responseSchema = Schema.Struct({
+const schema = Schema.Struct({
   limited: Schema.Boolean,
   results: Schema.Array(userResponseSchema),
 })
@@ -34,11 +34,5 @@ export const postUserDirectorySearchV3 = (options: Schema.Schema.Type<typeof opt
   Effect.gen(function* () {
     const body = yield* Schema.encodeEffect(optionsSchema.pipe(encodeSnakeCaseSchema))(options).pipe(Effect.andThen(HttpBody.json))
 
-    return yield* makeEndpoint({
-      auth: true,
-      method: 'POST',
-      path: apiPath()`/v3/user_directory/search`,
-      body,
-      schema: responseSchema,
-    })
+    return yield* makeEndpoint('POST', { auth: true, body, schema })`/v3/user_directory/search`
   })

--- a/src/api/schema/common.ts
+++ b/src/api/schema/common.ts
@@ -183,3 +183,12 @@ export const Timeline = Schema.Struct({
 })
 
 export const StateSchema = Schema.Struct({ events: Schema.Array(ClientEventWithoutRoomId) })
+
+export const RoomEvent = Schema.Union([
+  ClientEvent,
+  RoomMessageEvent,
+  RoomNameEventPartial,
+  RoomTopicEventPartial,
+  RoomAvatarEventPartial,
+  RoomPinnedEventsEventPartial,
+])


### PR DESCRIPTION
## Upgrade the endpoint interface to be more concise

Old interface:
```ts
export const getLoginV3 = () =>
  makeEndpoint({
    path: apiPath()`/v3/login`,
    method: 'GET',
    auth: false,
    schema: responseSchema,
  })
```

New interface: 
```ts
export const getLoginV3 = () => makeEndpoint('GET', { auth: false, schema })`/v3/login`
```


Open issues:
- Better body handling
- Fix HttpClient hierarchy expose auth/api/base client directly as right now the discovery endpoints are accessible externally but not usable without the base client which is not supposed to be used directly.