### PR TITLE
exploration: support legacy Matrix user IDs

### DIFF
--- a/packages/mxfx/src/branded/user-id.test.ts
+++ b/packages/mxfx/src/branded/user-id.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from '@effect/vitest'
-import { Effect, Exit } from 'effect'
+import { Effect, Exit, Schema } from 'effect'
 
 import { UserId } from './user-id.ts'
 
@@ -22,6 +22,22 @@ describe('branded', () => {
 
       const veryLongUserId = '@' + 'a'.repeat(244) + ':matrix.org'
       expect(Exit.isFailure(yield* Effect.exit(UserId.make(veryLongUserId)))).toBeTruthy()
+    }),
+  )
+
+  it.effect('should decode historical UserIds received from a server', () =>
+    Effect.gen(function* () {
+      const decode = Schema.decodeUnknownEffect(UserId.schema)
+
+      expect(yield* decode('@CapitalizedUserId:matrix.org')).toBe('@CapitalizedUserId:matrix.org')
+      expect(yield* decode('@legacy~user:matrix.org')).toBe('@legacy~user:matrix.org')
+    }),
+  )
+
+  it.effect('should not create new UserIds using the historical grammar', () =>
+    Effect.gen(function* () {
+      expect(Exit.isFailure(yield* Effect.exit(UserId.make('@CapitalizedUserId:matrix.org')))).toBeTruthy()
+      expect(Exit.isFailure(yield* Effect.exit(UserId.make('@legacy~user:matrix.org')))).toBeTruthy()
     }),
   )
 })

--- a/packages/mxfx/src/branded/user-id.test.ts
+++ b/packages/mxfx/src/branded/user-id.test.ts
@@ -29,8 +29,34 @@ describe('branded', () => {
     Effect.gen(function* () {
       const decode = Schema.decodeUnknownEffect(UserId.schema)
 
+      expect(yield* decode('@:matrix.org')).toBe('@:matrix.org')
       expect(yield* decode('@CapitalizedUserId:matrix.org')).toBe('@CapitalizedUserId:matrix.org')
       expect(yield* decode('@legacy~user:matrix.org')).toBe('@legacy~user:matrix.org')
+      expect(yield* decode('@\u00e9:matrix.org')).toBe('@\u00e9:matrix.org')
+      expect(yield* decode('@\ud83d\ude00:matrix.org')).toBe('@\ud83d\ude00:matrix.org')
+    }),
+  )
+
+  it.effect('should reject invalid Unicode in historical UserIds', () =>
+    Effect.gen(function* () {
+      const decode = Schema.decodeUnknownEffect(UserId.schema)
+
+      expect(Exit.isFailure(yield* Effect.exit(decode('@\ud800:matrix.org')))).toBeTruthy()
+      expect(Exit.isFailure(yield* Effect.exit(decode('@\udfff:matrix.org')))).toBeTruthy()
+      expect(Exit.isFailure(yield* Effect.exit(decode('@legacy\u0000user:matrix.org')))).toBeTruthy()
+    }),
+  )
+
+  it.effect('should enforce the 255-byte UTF-8 limit for historical UserIds', () =>
+    Effect.gen(function* () {
+      const decode = Schema.decodeUnknownEffect(UserId.schema)
+      const exactly255Bytes = `@${'\u00e9'.repeat(121)}a:matrix.org`
+      const moreThan255Bytes = `@${'\u00e9'.repeat(122)}:matrix.org`
+
+      expect(new TextEncoder().encode(exactly255Bytes).byteLength).toBe(255)
+      expect(yield* decode(exactly255Bytes)).toBe(exactly255Bytes)
+      expect(new TextEncoder().encode(moreThan255Bytes).byteLength).toBe(256)
+      expect(Exit.isFailure(yield* Effect.exit(decode(moreThan255Bytes)))).toBeTruthy()
     }),
   )
 

--- a/packages/mxfx/src/branded/user-id.ts
+++ b/packages/mxfx/src/branded/user-id.ts
@@ -4,20 +4,28 @@ import { opaqueId } from './opaque-id.ts'
 import { ServerName } from './server-name.ts'
 
 const localpart = opaqueId.check(Schema.isPattern(/^[a-z0-9._=\-/+]+$/))
+const historicalLocalpart = Schema.String.check(
+  Schema.isPattern(/^[^:\uD800-\uDFFF]*$/u),
+  Schema.makeFilter((input: string) => !input.includes('\u0000'), { expected: 'a localpart without a NUL character' }),
+)
+const utf8Encoder = new TextEncoder()
+const isValidUserIdByteLength = Schema.makeFilter((input: string) => utf8Encoder.encode(input).byteLength <= 255, {
+  expected: 'a user ID at most 255 bytes long when encoded as UTF-8',
+})
 
 /**
  * User IDs received from Matrix servers may use the historical, opaque localpart
  * grammar. Homeservers must continue accepting these IDs even though they may not
  * create new IDs using that grammar.
  */
-const schema = Schema.TemplateLiteral(['@', opaqueId, ':', ServerName.schema]).pipe(
-  Schema.check(Schema.isMaxLength(255)),
+const schema = Schema.TemplateLiteral(['@', historicalLocalpart, ':', ServerName.schema]).pipe(
+  Schema.check(isValidUserIdByteLength),
   Schema.brand('mxfx/UserId'),
 )
 
 /** The modern grammar used when constructing a new user ID in mxfx. */
 const creationSchema = Schema.TemplateLiteral(['@', localpart, ':', ServerName.schema]).pipe(
-  Schema.check(Schema.isMaxLength(255)),
+  Schema.check(isValidUserIdByteLength),
   Schema.brand('mxfx/UserId'),
 )
 

--- a/packages/mxfx/src/branded/user-id.ts
+++ b/packages/mxfx/src/branded/user-id.ts
@@ -5,10 +5,25 @@ import { ServerName } from './server-name.ts'
 
 const localpart = opaqueId.check(Schema.isPattern(/^[a-z0-9._=\-/+]+$/))
 
-const schema = Schema.TemplateLiteral(['@', localpart, ':', ServerName.schema]).pipe(
+/**
+ * User IDs received from Matrix servers may use the historical, opaque localpart
+ * grammar. Homeservers must continue accepting these IDs even though they may not
+ * create new IDs using that grammar.
+ */
+const schema = Schema.TemplateLiteral(['@', opaqueId, ':', ServerName.schema]).pipe(
+  Schema.check(Schema.isMaxLength(255)),
+  Schema.brand('mxfx/UserId'),
+)
+
+/** The modern grammar used when constructing a new user ID in mxfx. */
+const creationSchema = Schema.TemplateLiteral(['@', localpart, ':', ServerName.schema]).pipe(
   Schema.check(Schema.isMaxLength(255)),
   Schema.brand('mxfx/UserId'),
 )
 
 export type UserId = typeof schema.Type
-export const UserId = { schema, make: Schema.decodeUnknownEffect(schema) }
+export const UserId = {
+  schema,
+  creationSchema,
+  make: Schema.decodeUnknownEffect(creationSchema),
+}


### PR DESCRIPTION
Closes #9

## Summary
- accept historical opaque Matrix user ID localparts when decoding server responses
- retain the modern lowercase localpart grammar for UserId.make
- expose UserId.creationSchema for outgoing creation boundaries
- cover uppercase and otherwise historical localparts with regression tests

## Verification
- CI=true pnpm --filter mxfx test --run (73 tests passed)
- CI=true pnpm --filter mxfx typecheck
- CI=true pnpm fmt:check
- git diff --check
- targeted oxlint on changed files with type-aware checks disabled

## Caveat
The repository-wide pnpm lint command currently fails before linting because .oxlintrc.json enables type-aware checking but the tsgolint executable was removed on main. The changed files pass the non-type-aware oxlint rules, and TypeScript typechecking passes.